### PR TITLE
feat: rename module

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## Installation
 
 ```sh
-go get github.com/daoleno/uniswapv3-sdk
+go get github.com/KyberNetwork/uniswapv3-sdk
 ```
 
 ## Usage
@@ -24,9 +24,9 @@ import (
 	"math/big"
 
 	core "github.com/daoleno/uniswap-sdk-core/entities"
-	"github.com/daoleno/uniswapv3-sdk/constants"
-	"github.com/daoleno/uniswapv3-sdk/entities"
-	"github.com/daoleno/uniswapv3-sdk/utils"
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
+	"github.com/KyberNetwork/uniswapv3-sdk/entities"
+	"github.com/KyberNetwork/uniswapv3-sdk/utils"
 	"github.com/ethereum/go-ethereum/common"
 )
 

--- a/entities/nearestusabletick.go
+++ b/entities/nearestusabletick.go
@@ -3,7 +3,7 @@ package entities
 import (
 	"math"
 
-	"github.com/daoleno/uniswapv3-sdk/utils"
+	"github.com/KyberNetwork/uniswapv3-sdk/utils"
 )
 
 /**

--- a/entities/nearestusabletick_test.go
+++ b/entities/nearestusabletick_test.go
@@ -3,7 +3,7 @@ package entities
 import (
 	"testing"
 
-	"github.com/daoleno/uniswapv3-sdk/utils"
+	"github.com/KyberNetwork/uniswapv3-sdk/utils"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/entities/pool.go
+++ b/entities/pool.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"math/big"
 
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
+	"github.com/KyberNetwork/uniswapv3-sdk/utils"
 	"github.com/daoleno/uniswap-sdk-core/entities"
-	"github.com/daoleno/uniswapv3-sdk/constants"
-	"github.com/daoleno/uniswapv3-sdk/utils"
 	"github.com/ethereum/go-ethereum/common"
 )
 

--- a/entities/pool_test.go
+++ b/entities/pool_test.go
@@ -4,9 +4,9 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
+	"github.com/KyberNetwork/uniswapv3-sdk/utils"
 	"github.com/daoleno/uniswap-sdk-core/entities"
-	"github.com/daoleno/uniswapv3-sdk/constants"
-	"github.com/daoleno/uniswapv3-sdk/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 )

--- a/entities/position.go
+++ b/entities/position.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"math/big"
 
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
+	"github.com/KyberNetwork/uniswapv3-sdk/utils"
 	"github.com/daoleno/uniswap-sdk-core/entities"
-	"github.com/daoleno/uniswapv3-sdk/constants"
-	"github.com/daoleno/uniswapv3-sdk/utils"
 )
 
 var (

--- a/entities/position_test.go
+++ b/entities/position_test.go
@@ -4,9 +4,9 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
+	"github.com/KyberNetwork/uniswapv3-sdk/utils"
 	"github.com/daoleno/uniswap-sdk-core/entities"
-	"github.com/daoleno/uniswapv3-sdk/constants"
-	"github.com/daoleno/uniswapv3-sdk/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"

--- a/entities/route_test.go
+++ b/entities/route_test.go
@@ -4,9 +4,9 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
+	"github.com/KyberNetwork/uniswapv3-sdk/utils"
 	"github.com/daoleno/uniswap-sdk-core/entities"
-	"github.com/daoleno/uniswapv3-sdk/constants"
-	"github.com/daoleno/uniswapv3-sdk/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 )

--- a/entities/ticklist.go
+++ b/entities/ticklist.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"math/big"
 
-	"github.com/daoleno/uniswapv3-sdk/constants"
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
 )
 
 const (

--- a/entities/ticklist_test.go
+++ b/entities/ticklist_test.go
@@ -4,7 +4,7 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/daoleno/uniswapv3-sdk/utils"
+	"github.com/KyberNetwork/uniswapv3-sdk/utils"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/entities/trade.go
+++ b/entities/trade.go
@@ -5,8 +5,8 @@ import (
 	"math/big"
 	"sort"
 
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
 	"github.com/daoleno/uniswap-sdk-core/entities"
-	"github.com/daoleno/uniswapv3-sdk/constants"
 	"github.com/ethereum/go-ethereum/common"
 )
 

--- a/entities/trade_test.go
+++ b/entities/trade_test.go
@@ -4,9 +4,9 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
+	"github.com/KyberNetwork/uniswapv3-sdk/utils"
 	"github.com/daoleno/uniswap-sdk-core/entities"
-	"github.com/daoleno/uniswapv3-sdk/constants"
-	"github.com/daoleno/uniswapv3-sdk/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 )

--- a/examples/helper/pool.go
+++ b/examples/helper/pool.go
@@ -4,12 +4,12 @@ import (
 	"errors"
 	"math/big"
 
-	"github.com/daoleno/uniswapv3-sdk/examples/contract"
+	"github.com/KyberNetwork/uniswapv3-sdk/examples/contract"
 
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
+	"github.com/KyberNetwork/uniswapv3-sdk/entities"
+	sdkutils "github.com/KyberNetwork/uniswapv3-sdk/utils"
 	coreEntities "github.com/daoleno/uniswap-sdk-core/entities"
-	"github.com/daoleno/uniswapv3-sdk/constants"
-	"github.com/daoleno/uniswapv3-sdk/entities"
-	sdkutils "github.com/daoleno/uniswapv3-sdk/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 )

--- a/examples/liquidity/main.go
+++ b/examples/liquidity/main.go
@@ -7,18 +7,18 @@ import (
 	"strings"
 	"time"
 
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
+	"github.com/KyberNetwork/uniswapv3-sdk/entities"
+	"github.com/KyberNetwork/uniswapv3-sdk/examples/contract"
+	"github.com/KyberNetwork/uniswapv3-sdk/examples/helper"
+	"github.com/KyberNetwork/uniswapv3-sdk/periphery"
 	coreEntities "github.com/daoleno/uniswap-sdk-core/entities"
-	"github.com/daoleno/uniswapv3-sdk/constants"
-	"github.com/daoleno/uniswapv3-sdk/entities"
-	"github.com/daoleno/uniswapv3-sdk/examples/contract"
-	"github.com/daoleno/uniswapv3-sdk/examples/helper"
-	"github.com/daoleno/uniswapv3-sdk/periphery"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
-//mint a new liquidity
+// mint a new liquidity
 func mintOrAdd(client *ethclient.Client, wallet *helper.Wallet, tokenID *big.Int) {
 	log.SetFlags(log.Lshortfile | log.LstdFlags)
 

--- a/examples/quoter/main.go
+++ b/examples/quoter/main.go
@@ -6,8 +6,8 @@ import (
 
 	"log"
 
-	"github.com/daoleno/uniswapv3-sdk/examples/contract"
-	"github.com/daoleno/uniswapv3-sdk/examples/helper"
+	"github.com/KyberNetwork/uniswapv3-sdk/examples/contract"
+	"github.com/KyberNetwork/uniswapv3-sdk/examples/helper"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 )

--- a/examples/swap/main.go
+++ b/examples/swap/main.go
@@ -7,11 +7,11 @@ import (
 
 	"log"
 
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
+	"github.com/KyberNetwork/uniswapv3-sdk/entities"
+	"github.com/KyberNetwork/uniswapv3-sdk/examples/helper"
+	"github.com/KyberNetwork/uniswapv3-sdk/periphery"
 	coreEntities "github.com/daoleno/uniswap-sdk-core/entities"
-	"github.com/daoleno/uniswapv3-sdk/constants"
-	"github.com/daoleno/uniswapv3-sdk/entities"
-	"github.com/daoleno/uniswapv3-sdk/examples/helper"
-	"github.com/daoleno/uniswapv3-sdk/periphery"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 )

--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,8 @@ module github.com/KyberNetwork/uniswapv3-sdk
 
 go 1.18
 
-replace github.com/daoleno/uniswapv3-sdk v0.4.0 => github.com/KyberNetwork/uniswapv3-sdk v0.4.0
-
 require (
 	github.com/daoleno/uniswap-sdk-core v0.1.5
-	github.com/daoleno/uniswapv3-sdk v0.4.0
 	github.com/ethereum/go-ethereum v1.10.20
 	github.com/shopspring/decimal v1.3.1
 	github.com/stretchr/testify v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/KyberNetwork/uniswapv3-sdk v0.4.0 h1:hbTeJBFgFqYqYTduGuEnb4JIvCtcmuvBTFuRARJIa1Y=
-github.com/KyberNetwork/uniswapv3-sdk v0.4.0/go.mod h1:K+cqy6zkitxxfShghmuoVwjGJWO16FTXAV+dvddXtgw=
 github.com/VictoriaMetrics/fastcache v1.6.0 h1:C/3Oi3EiBCqufydp1neRZkqcwmEiuRT9c3fqvvgKm5o=
 github.com/btcsuite/btcd/btcec/v2 v2.2.0 h1:fzn1qaOt32TuLjFlkzYSsBC35Q3KUjT1SwPxiMSCF5k=
 github.com/btcsuite/btcd/btcec/v2 v2.2.0/go.mod h1:U7MHm051Al6XmscBQ0BoNydpOTsFAn707034b5nY8zU=

--- a/periphery/const_test.go
+++ b/periphery/const_test.go
@@ -3,10 +3,10 @@ package periphery
 import (
 	"math/big"
 
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
+	"github.com/KyberNetwork/uniswapv3-sdk/entities"
+	"github.com/KyberNetwork/uniswapv3-sdk/utils"
 	core "github.com/daoleno/uniswap-sdk-core/entities"
-	"github.com/daoleno/uniswapv3-sdk/constants"
-	"github.com/daoleno/uniswapv3-sdk/entities"
-	"github.com/daoleno/uniswapv3-sdk/utils"
 	"github.com/ethereum/go-ethereum/common"
 )
 

--- a/periphery/nonfungible_position_manager.go
+++ b/periphery/nonfungible_position_manager.go
@@ -6,10 +6,10 @@ import (
 	"errors"
 	"math/big"
 
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
+	"github.com/KyberNetwork/uniswapv3-sdk/entities"
+	"github.com/KyberNetwork/uniswapv3-sdk/utils"
 	core "github.com/daoleno/uniswap-sdk-core/entities"
-	"github.com/daoleno/uniswapv3-sdk/constants"
-	"github.com/daoleno/uniswapv3-sdk/entities"
-	"github.com/daoleno/uniswapv3-sdk/utils"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -43,7 +43,7 @@ type IncreaseSpecificOptions struct {
 	TokenID *big.Int // Indicates the ID of the position to increase liquidity for
 }
 
-//  Options for producing the calldata to add liquidity
+// Options for producing the calldata to add liquidity
 type CommonAddLiquidityOptions struct {
 	SlippageTolerance *core.Percent  // How much the pool price is allowed to move
 	Deadline          *big.Int       // When the transaction expires, in epoch seconds

--- a/periphery/nonfungible_position_manager_test.go
+++ b/periphery/nonfungible_position_manager_test.go
@@ -4,10 +4,10 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
+	"github.com/KyberNetwork/uniswapv3-sdk/entities"
+	"github.com/KyberNetwork/uniswapv3-sdk/utils"
 	core "github.com/daoleno/uniswap-sdk-core/entities"
-	"github.com/daoleno/uniswapv3-sdk/constants"
-	"github.com/daoleno/uniswapv3-sdk/entities"
-	"github.com/daoleno/uniswapv3-sdk/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/assert"

--- a/periphery/quoter.go
+++ b/periphery/quoter.go
@@ -7,9 +7,9 @@ import (
 	"math/big"
 	"reflect"
 
+	"github.com/KyberNetwork/uniswapv3-sdk/entities"
+	"github.com/KyberNetwork/uniswapv3-sdk/utils"
 	core "github.com/daoleno/uniswap-sdk-core/entities"
-	"github.com/daoleno/uniswapv3-sdk/entities"
-	"github.com/daoleno/uniswapv3-sdk/utils"
 	"github.com/ethereum/go-ethereum/common"
 )
 

--- a/periphery/quoter_test.go
+++ b/periphery/quoter_test.go
@@ -4,9 +4,9 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/KyberNetwork/uniswapv3-sdk/entities"
+	"github.com/KyberNetwork/uniswapv3-sdk/utils"
 	core "github.com/daoleno/uniswap-sdk-core/entities"
-	"github.com/daoleno/uniswapv3-sdk/entities"
-	"github.com/daoleno/uniswapv3-sdk/utils"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/assert"
 )

--- a/periphery/staker.go
+++ b/periphery/staker.go
@@ -4,9 +4,9 @@ import (
 	_ "embed"
 	"math/big"
 
+	"github.com/KyberNetwork/uniswapv3-sdk/entities"
+	"github.com/KyberNetwork/uniswapv3-sdk/utils"
 	core "github.com/daoleno/uniswap-sdk-core/entities"
-	"github.com/daoleno/uniswapv3-sdk/entities"
-	"github.com/daoleno/uniswapv3-sdk/utils"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 )

--- a/periphery/staker_test.go
+++ b/periphery/staker_test.go
@@ -4,10 +4,10 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
+	"github.com/KyberNetwork/uniswapv3-sdk/entities"
+	"github.com/KyberNetwork/uniswapv3-sdk/utils"
 	core "github.com/daoleno/uniswap-sdk-core/entities"
-	"github.com/daoleno/uniswapv3-sdk/constants"
-	"github.com/daoleno/uniswapv3-sdk/entities"
-	"github.com/daoleno/uniswapv3-sdk/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/assert"

--- a/periphery/swaprouter.go
+++ b/periphery/swaprouter.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"math/big"
 
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
+	"github.com/KyberNetwork/uniswapv3-sdk/entities"
+	"github.com/KyberNetwork/uniswapv3-sdk/utils"
 	core "github.com/daoleno/uniswap-sdk-core/entities"
-	"github.com/daoleno/uniswapv3-sdk/constants"
-	"github.com/daoleno/uniswapv3-sdk/entities"
-	"github.com/daoleno/uniswapv3-sdk/utils"
 	"github.com/ethereum/go-ethereum/common"
 )
 

--- a/periphery/swaprouter_test.go
+++ b/periphery/swaprouter_test.go
@@ -4,9 +4,9 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/KyberNetwork/uniswapv3-sdk/entities"
+	"github.com/KyberNetwork/uniswapv3-sdk/utils"
 	core "github.com/daoleno/uniswap-sdk-core/entities"
-	"github.com/daoleno/uniswapv3-sdk/entities"
-	"github.com/daoleno/uniswapv3-sdk/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/assert"

--- a/utils/compute_pool_address.go
+++ b/utils/compute_pool_address.go
@@ -3,8 +3,8 @@ package utils
 import (
 	"math/big"
 
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
 	"github.com/daoleno/uniswap-sdk-core/entities"
-	"github.com/daoleno/uniswapv3-sdk/constants"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"

--- a/utils/compute_pool_address_test.go
+++ b/utils/compute_pool_address_test.go
@@ -3,8 +3,8 @@ package utils
 import (
 	"testing"
 
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
 	"github.com/daoleno/uniswap-sdk-core/entities"
-	"github.com/daoleno/uniswapv3-sdk/constants"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 )

--- a/utils/encode_test.go
+++ b/utils/encode_test.go
@@ -4,7 +4,7 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/daoleno/uniswapv3-sdk/constants"
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/utils/full_math.go
+++ b/utils/full_math.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"math/big"
 
-	"github.com/daoleno/uniswapv3-sdk/constants"
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
 )
 
 func MulDivRoundingUp(a, b, denominator *big.Int) *big.Int {

--- a/utils/liquidity_math.go
+++ b/utils/liquidity_math.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"math/big"
 
-	"github.com/daoleno/uniswapv3-sdk/constants"
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
 )
 
 func AddDelta(x, y *big.Int) *big.Int {

--- a/utils/max_liquidity_for_amounts.go
+++ b/utils/max_liquidity_for_amounts.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"math/big"
 
-	"github.com/daoleno/uniswapv3-sdk/constants"
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
 )
 
 /**

--- a/utils/most_significant_bit.go
+++ b/utils/most_significant_bit.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"math/big"
 
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
 	"github.com/daoleno/uniswap-sdk-core/entities"
-	"github.com/daoleno/uniswapv3-sdk/constants"
 )
 
 var ErrInvalidInput = errors.New("invalid input")

--- a/utils/price_tick_conversions.go
+++ b/utils/price_tick_conversions.go
@@ -3,8 +3,8 @@ package utils
 import (
 	"math/big"
 
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
 	"github.com/daoleno/uniswap-sdk-core/entities"
-	"github.com/daoleno/uniswapv3-sdk/constants"
 )
 
 /**

--- a/utils/sqrtprice_math.go
+++ b/utils/sqrtprice_math.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"math/big"
 
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
 	"github.com/daoleno/uniswap-sdk-core/entities"
-	"github.com/daoleno/uniswapv3-sdk/constants"
 )
 
 var (

--- a/utils/swap_math.go
+++ b/utils/swap_math.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"math/big"
 
-	"github.com/daoleno/uniswapv3-sdk/constants"
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
 )
 
 var MaxFee = new(big.Int).Exp(big.NewInt(10), big.NewInt(6), nil)

--- a/utils/tick_math.go
+++ b/utils/tick_math.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"math/big"
 
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
 	"github.com/daoleno/uniswap-sdk-core/entities"
-	"github.com/daoleno/uniswapv3-sdk/constants"
 )
 
 const (

--- a/utils/tick_math_test.go
+++ b/utils/tick_math_test.go
@@ -4,7 +4,7 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/daoleno/uniswapv3-sdk/constants"
+	"github.com/KyberNetwork/uniswapv3-sdk/constants"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
Because we forked this project and create a new module as "github.com/KyberNetwork/uniswapv3-sdk". So I wanna rename this module to refer to our project, instead of the original module.

Because of when we get this module, it's will be referred the original module in the local environment. We can rename to use own project.