### PR TITLE
feat: add UniswapV3 factory address

### DIFF
--- a/utils/compute_pool_address.go
+++ b/utils/compute_pool_address.go
@@ -10,6 +10,10 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
+var (
+	UniswapV3FactoryAddress = common.HexToAddress("0x1f98431c8ad98523631ae4a59f267346ea31f984")
+)
+
 /**
  * Computes a pool address
  * @param factoryAddress The Uniswap V3 factory address
@@ -18,7 +22,7 @@ import (
  * @param fee The fee tier of the pool
  * @returns The pool address
  */
-func ComputePoolAddress(factoryAddress common.Address, tokenA *entities.Token, tokenB *entities.Token, fee constants.FeeAmount, initCodeHashManualOverride string) (common.Address, error) {
+func ComputePoolAddress(tokenA *entities.Token, tokenB *entities.Token, fee constants.FeeAmount, initCodeHashManualOverride string) (common.Address, error) {
 	isSorted, err := tokenA.SortsBefore(tokenB)
 	if err != nil {
 		return common.Address{}, err
@@ -34,17 +38,17 @@ func ComputePoolAddress(factoryAddress common.Address, tokenA *entities.Token, t
 		token0 = tokenB
 		token1 = tokenA
 	}
-	return getCreate2Address(factoryAddress, token0.Address, token1.Address, fee, initCodeHashManualOverride), nil
+	return getCreate2Address(token0.Address, token1.Address, fee, initCodeHashManualOverride), nil
 }
 
-func getCreate2Address(factoyAddress, addressA, addressB common.Address, fee constants.FeeAmount, initCodeHashManualOverride string) common.Address {
+func getCreate2Address(addressA, addressB common.Address, fee constants.FeeAmount, initCodeHashManualOverride string) common.Address {
 	var salt [32]byte
 	copy(salt[:], crypto.Keccak256(abiEncode(addressA, addressB, fee)))
 
 	if initCodeHashManualOverride != "" {
-		crypto.CreateAddress2(factoyAddress, salt, common.FromHex(initCodeHashManualOverride))
+		crypto.CreateAddress2(UniswapV3FactoryAddress, salt, common.FromHex(initCodeHashManualOverride))
 	}
-	return crypto.CreateAddress2(factoyAddress, salt, common.FromHex(constants.PoolInitCodeHash))
+	return crypto.CreateAddress2(UniswapV3FactoryAddress, salt, common.FromHex(constants.PoolInitCodeHash))
 }
 
 func abiEncode(addressA, addressB common.Address, fee constants.FeeAmount) []byte {

--- a/utils/compute_pool_address_test.go
+++ b/utils/compute_pool_address_test.go
@@ -10,10 +10,9 @@ import (
 )
 
 func TestComputePoolAddress(t *testing.T) {
-	factoryAddress := common.HexToAddress("0x1111111111111111111111111111111111111111")
 	tokenA := entities.NewToken(1, common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"), 18, "USDC", "USD Coin")
 	tokenB := entities.NewToken(1, common.HexToAddress("0x6B175474E89094C44Da98b954EedeAC495271d0F"), 18, "DAI", "Dai Stablecoin")
-	result, err := ComputePoolAddress(factoryAddress, tokenA, tokenB, constants.FeeLow, "")
+	result, err := ComputePoolAddress(tokenA, tokenB, constants.FeeLow, "")
 	if err != nil {
 		panic(err)
 	}
@@ -21,11 +20,11 @@ func TestComputePoolAddress(t *testing.T) {
 
 	USDC := entities.NewToken(1, common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"), 18, "USDC", "USD Coin")
 	DAI := entities.NewToken(1, common.HexToAddress("0x6B175474E89094C44Da98b954EedeAC495271d0F"), 18, "DAI", "Dai Stablecoin")
-	resultA, err := ComputePoolAddress(factoryAddress, USDC, DAI, constants.FeeLow, "")
+	resultA, err := ComputePoolAddress(USDC, DAI, constants.FeeLow, "")
 	if err != nil {
 		panic(err)
 	}
-	resultB, err := ComputePoolAddress(factoryAddress, DAI, USDC, constants.FeeLow, "")
+	resultB, err := ComputePoolAddress(DAI, USDC, constants.FeeLow, "")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
UniswapV3 Factory Address is mentioned in the official documents so we don't need to pass this every times we generate the pair address from token0, token1 and fee.

References:
- [Etherscan](https://etherscan.io/address/0x1f98431c8ad98523631ae4a59f267346ea31f984)
- [UniswapV3 docs](https://docs.uniswap.org/contracts/v3/reference/deployments)