### PR TITLE
optimize logic and reduce alloc

### DIFF
--- a/entities/pool.go
+++ b/entities/pool.go
@@ -62,6 +62,7 @@ type GetAmountResult struct {
 
 type GetAmountResultV2 struct {
 	ReturnedAmount     *utils.Int256
+	RemainingAmountIn  *utils.Int256
 	SqrtRatioX96       *utils.Uint160
 	Liquidity          *utils.Uint128
 	CurrentTick        int
@@ -232,6 +233,7 @@ func (p *Pool) GetOutputAmountV2(inputAmount *utils.Int256, zeroForOne bool, sqr
 	}
 	return &GetAmountResultV2{
 		ReturnedAmount:     new(utils.Int256).Neg(swapResult.amountCalculated),
+		RemainingAmountIn:  new(utils.Int256).Set(swapResult.remainingAmountIn),
 		SqrtRatioX96:       swapResult.sqrtRatioX96,
 		Liquidity:          swapResult.liquidity,
 		CurrentTick:        swapResult.currentTick,

--- a/utils/full_math.go
+++ b/utils/full_math.go
@@ -30,6 +30,127 @@ func MulDivRoundingUp(a, b, denominator *uint256.Int) (*uint256.Int, error) {
 	return resultU, nil
 }
 
+func MulDivRoundingUpV2(a, b, denominator, result *uint256.Int) error {
+	var remainder Uint256
+	err := MulDivV2(a, b, denominator, result, &remainder)
+	if err != nil {
+		return err
+	}
+
+	if !remainder.IsZero() {
+		if result.Cmp(MaxUint256) == 0 {
+			return ErrInvariant
+		}
+		result.AddUint64(result, 1)
+	}
+	return nil
+}
+
+// result=floor(a×b÷denominator), remainder=a×b%denominator
+// (pass remainder=nil if not required)
+func MulDivV2(a, b, denominator, result, remainder *uint256.Int) error {
+	// https://github.com/Uniswap/v3-core/blob/main/contracts/libraries/FullMath.sol
+	// 512-bit multiply [prod1 prod0] = a * b
+	// Compute the product mod 2**256 and mod 2**256 - 1
+	// then use the Chinese Remainder Theorem to reconstruct
+	// the 512 bit result. The result is stored in two 256
+	// variables such that product = prod1 * 2**256 + prod0
+	var prod0 Uint256 // Least significant 256 bits of the product
+	var prod1 Uint256 // Most significant 256 bits of the product
+
+	var denominatorTmp Uint256 // temp var (need to modify denominator along the way)
+	denominatorTmp.Set(denominator)
+
+	var mm Uint256
+	mm.MulMod(a, b, MaxUint256)
+	prod0.Mul(a, b)
+	prod1.Sub(&mm, &prod0)
+	if mm.Cmp(&prod0) < 0 {
+		prod1.SubUint64(&prod1, 1)
+	}
+
+	// Handle non-overflow cases, 256 by 256 division
+	if prod1.IsZero() {
+		if denominatorTmp.IsZero() {
+			return ErrInvariant
+		}
+
+		if remainder != nil {
+			remainder.MulMod(a, b, &denominatorTmp)
+		}
+		result.Div(&prod0, &denominatorTmp)
+		return nil
+	}
+
+	// Make sure the result is less than 2**256.
+	// Also prevents denominator == 0
+	if denominatorTmp.Cmp(&prod1) <= 0 {
+		return ErrInvariant
+	}
+
+	///////////////////////////////////////////////
+	// 512 by 256 division.
+	///////////////////////////////////////////////
+
+	// Make division exact by subtracting the remainder from [prod1 prod0]
+	// Compute remainder using mulmod
+	if remainder == nil {
+		var remainderTmp Uint256
+		remainder = &remainderTmp
+	}
+	remainder.MulMod(a, b, &denominatorTmp)
+	// Subtract 256 bit number from 512 bit number
+	if remainder.Cmp(&prod0) > 0 {
+		prod1.SubUint64(&prod1, 1)
+	}
+	prod0.Sub(&prod0, remainder)
+
+	// Factor powers of two out of denominator
+	// Compute largest power of two divisor of denominator.
+	// Always >= 1.
+	var twos, tmp, tmp1, zero, two, three Uint256
+	twos.And(tmp.Neg(&denominatorTmp), &denominatorTmp)
+	// Divide denominator by power of two
+	denominatorTmp.Div(&denominatorTmp, &twos)
+
+	// Divide [prod1 prod0] by the factors of two
+	prod0.Div(&prod0, &twos)
+	// Shift in bits from prod1 into prod0. For this we need
+	// to flip `twos` such that it is 2**256 / twos.
+	// If twos is zero, then it becomes one
+	zero.Clear()
+	twos.AddUint64(tmp.Div(tmp1.Sub(&zero, &twos), &twos), 1)
+	prod0.Or(&prod0, tmp.Mul(&prod1, &twos))
+
+	// Invert denominator mod 2**256
+	// Now that denominator is an odd number, it has an inverse
+	// modulo 2**256 such that denominator * inv = 1 mod 2**256.
+	// Compute the inverse by starting with a seed that is correct
+	// correct for four bits. That is, denominator * inv = 1 mod 2**4
+	var inv Uint256
+	two.SetUint64(2)
+	three.SetUint64(3)
+	inv.Xor(tmp.Mul(&denominatorTmp, &three), &two)
+	// Now use Newton-Raphson iteration to improve the precision.
+	// Thanks to Hensel's lifting lemma, this also works in modular
+	// arithmetic, doubling the correct bits in each step.
+	inv.Mul(&inv, tmp.Sub(&two, tmp1.Mul(&denominatorTmp, &inv))) // inverse mod 2**8
+	inv.Mul(&inv, tmp.Sub(&two, tmp1.Mul(&denominatorTmp, &inv))) // inverse mod 2**16
+	inv.Mul(&inv, tmp.Sub(&two, tmp1.Mul(&denominatorTmp, &inv))) // inverse mod 2**32
+	inv.Mul(&inv, tmp.Sub(&two, tmp1.Mul(&denominatorTmp, &inv))) // inverse mod 2**64
+	inv.Mul(&inv, tmp.Sub(&two, tmp1.Mul(&denominatorTmp, &inv))) // inverse mod 2**128
+	inv.Mul(&inv, tmp.Sub(&two, tmp1.Mul(&denominatorTmp, &inv))) // inverse mod 2**256
+
+	// Because the division is now exact we can divide by multiplying
+	// with the modular inverse of denominator. This will give us the
+	// correct result modulo 2**256. Since the precoditions guarantee
+	// that the outcome is less than 2**256, this is the final result.
+	// We don't need to compute the high bits of the result and prod1
+	// is no longer required.
+	result.Mul(&prod0, &inv)
+	return nil
+}
+
 // Calculates floor(a×b÷denominator) with full precision
 func MulDiv(a, b, denominator *uint256.Int) (*uint256.Int, error) {
 	// the product can overflow so need to use big.Int here

--- a/utils/full_math.go
+++ b/utils/full_math.go
@@ -48,6 +48,7 @@ func MulDivRoundingUpV2(a, b, denominator, result *uint256.Int) error {
 
 // result=floor(a×b÷denominator), remainder=a×b%denominator
 // (pass remainder=nil if not required)
+// (the main usage for `remainder` is to be used in `MulDivRoundingUpV2` to determine if we need to round up, so it won't have to call MulMod again)
 func MulDivV2(a, b, denominator, result, remainder *uint256.Int) error {
 	// https://github.com/Uniswap/v3-core/blob/main/contracts/libraries/FullMath.sol
 	// 512-bit multiply [prod1 prod0] = a * b
@@ -76,6 +77,7 @@ func MulDivV2(a, b, denominator, result, remainder *uint256.Int) error {
 		}
 
 		if remainder != nil {
+			// if the caller request then calculate remainder
 			remainder.MulMod(a, b, &denominatorTmp)
 		}
 		result.Div(&prod0, &denominatorTmp)
@@ -95,6 +97,7 @@ func MulDivV2(a, b, denominator, result, remainder *uint256.Int) error {
 	// Make division exact by subtracting the remainder from [prod1 prod0]
 	// Compute remainder using mulmod
 	if remainder == nil {
+		// the caller doesn't request but we need it so use a temporary variable here
 		var remainderTmp Uint256
 		remainder = &remainderTmp
 	}

--- a/utils/full_math.go
+++ b/utils/full_math.go
@@ -167,11 +167,10 @@ func MulDiv(a, b, denominator *uint256.Int) (*uint256.Int, error) {
 }
 
 // Returns ceil(x / y)
-func DivRoundingUp(a, denominator *uint256.Int) *uint256.Int {
-	var result, rem uint256.Int
+func DivRoundingUp(a, denominator, result *uint256.Int) {
+	var rem uint256.Int
 	result.DivMod(a, denominator, &rem)
 	if !rem.IsZero() {
-		result.AddUint64(&result, 1)
+		result.AddUint64(result, 1)
 	}
-	return &result
 }

--- a/utils/full_math_test.go
+++ b/utils/full_math_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
 
 	"github.com/holiman/uint256"
@@ -22,6 +23,8 @@ func TestMulDiv(t *testing.T) {
 		{"0x100000000000000000000000000000000", "0x80000000000000000000000000000000", "0x180000000000000000000000000000000", "113427455640312821154458202477256070485"},
 		{"0x100000000000000000000000000000000", "0x2300000000000000000000000000000000", "0x800000000000000000000000000000000", "1488735355279105777652263907513985925120"},
 		{"0x100000000000000000000000000000000", "0x3e800000000000000000000000000000000", "0xbb800000000000000000000000000000000", "113427455640312821154458202477256070485"},
+
+		{"0x61ae64157b363469ec1e000000000000000000000000", "0x5d5502f19f7baee2e5fa2", "0x69b797741ba66bda48a81e9", "126036350226489723925526476841950279379016090973169"},
 	}
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("test %d", i), func(t *testing.T) {
@@ -30,6 +33,13 @@ func TestMulDiv(t *testing.T) {
 				uint256.MustFromHex(tt.deno))
 			require.Nil(t, err)
 			assert.Equal(t, tt.expResult, r.Dec())
+
+			// v2
+			var rv2 Uint256
+			err = MulDivV2(uint256.MustFromHex(tt.a), uint256.MustFromHex(tt.b),
+				uint256.MustFromHex(tt.deno), &rv2, nil)
+			require.Nil(t, err)
+			assert.Equal(t, tt.expResult, rv2.Dec())
 		})
 	}
 
@@ -49,6 +59,54 @@ func TestMulDiv(t *testing.T) {
 				uint256.MustFromHex(tt.a), uint256.MustFromHex(tt.b),
 				uint256.MustFromHex(tt.deno))
 			require.NotNil(t, err)
+
+			// v2
+			var rv2 Uint256
+			err = MulDivV2(uint256.MustFromHex(tt.a), uint256.MustFromHex(tt.b),
+				uint256.MustFromHex(tt.deno), &rv2, nil)
+			require.NotNil(t, err)
+		})
+	}
+}
+
+func RandNumberHexString(maxLen int) string {
+	sLen := rand.Intn(maxLen) + 1
+	var s string
+	for i := 0; i < sLen; i++ {
+		var c int
+		if i == 0 {
+			c = rand.Intn(15) + 1
+		} else {
+			c = rand.Intn(16)
+		}
+		s = fmt.Sprintf("%s%x", s, c)
+	}
+	return s
+}
+
+func RandUint256() *Uint256 {
+	s := RandNumberHexString(64)
+	return uint256.MustFromHex("0x" + s)
+}
+
+func TestMulDivV2(t *testing.T) {
+	for i := 0; i < 500; i++ {
+		a := RandUint256()
+		b := RandUint256()
+		deno := RandUint256()
+
+		t.Run(fmt.Sprintf("test %s %s %s", a.Hex(), b.Hex(), deno.Hex()), func(t *testing.T) {
+			r, err := MulDiv(a, b, deno)
+
+			var rv2 Uint256
+			errv2 := MulDivV2(a, b, deno, &rv2, nil)
+
+			if err != nil {
+				require.NotNil(t, errv2)
+			} else {
+				require.Nil(t, errv2)
+				assert.Equal(t, r.Dec(), rv2.Dec())
+			}
 		})
 	}
 }
@@ -66,6 +124,8 @@ func TestMulDivRoundingUp(t *testing.T) {
 		{"0x100000000000000000000000000000000", "0x80000000000000000000000000000000", "0x180000000000000000000000000000000", "113427455640312821154458202477256070486"},
 		{"0x100000000000000000000000000000000", "0x2300000000000000000000000000000000", "0x800000000000000000000000000000000", "1488735355279105777652263907513985925120"},
 		{"0x100000000000000000000000000000000", "0x3e800000000000000000000000000000000", "0xbb800000000000000000000000000000000", "113427455640312821154458202477256070486"},
+
+		{"0x2a60f4810d72e89eaee06f20122f1de80adc64777e121", "0xfd21718acef075500c6395ba922064220", "0xd195e7433221b9e4b6ef3f19b457c9c9797ae6b5eaacb402113dce147e97979f", "14406918379743960"},
 	}
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("test %d", i), func(t *testing.T) {
@@ -74,6 +134,14 @@ func TestMulDivRoundingUp(t *testing.T) {
 				uint256.MustFromHex(tt.deno))
 			require.Nil(t, err)
 			assert.Equal(t, tt.expResult, r.Dec())
+
+			// v2
+			var rv2 Uint256
+			err = MulDivRoundingUpV2(
+				uint256.MustFromHex(tt.a), uint256.MustFromHex(tt.b),
+				uint256.MustFromHex(tt.deno), &rv2)
+			require.Nil(t, err)
+			assert.Equal(t, tt.expResult, rv2.Dec())
 		})
 	}
 
@@ -95,6 +163,35 @@ func TestMulDivRoundingUp(t *testing.T) {
 				uint256.MustFromHex(tt.a), uint256.MustFromHex(tt.b),
 				uint256.MustFromHex(tt.deno))
 			require.NotNil(t, err, x)
+
+			// v2
+			var rv2 Uint256
+			err = MulDivRoundingUpV2(
+				uint256.MustFromHex(tt.a), uint256.MustFromHex(tt.b),
+				uint256.MustFromHex(tt.deno), &rv2)
+			require.NotNil(t, err)
+		})
+	}
+}
+
+func TestMulDivRoundingUpV2(t *testing.T) {
+	for i := 0; i < 500; i++ {
+		a := RandUint256()
+		b := RandUint256()
+		deno := RandUint256()
+
+		t.Run(fmt.Sprintf("test %s %s %s", a.Hex(), b.Hex(), deno.Hex()), func(t *testing.T) {
+			r, err := MulDivRoundingUp(a, b, deno)
+
+			var rv2 Uint256
+			errv2 := MulDivRoundingUpV2(a, b, deno, &rv2)
+
+			if err != nil {
+				require.NotNil(t, errv2)
+			} else {
+				require.Nil(t, errv2)
+				assert.Equal(t, r.Dec(), rv2.Dec())
+			}
 		})
 	}
 }

--- a/utils/int_types.go
+++ b/utils/int_types.go
@@ -38,6 +38,13 @@ func ToInt256(value *Uint256, result *Int256) error {
 	return nil
 }
 
+func ToUInt256(value *Int256, result *Uint256) error {
+	var ba [32]byte
+	value.WriteToArray32(&ba)
+	result.SetBytes32(ba[:])
+	return nil
+}
+
 // https://github.com/Uniswap/v3-core/blob/main/contracts/libraries/SafeCast.sol
 func CheckToUint160(value *Uint256) error {
 	// we're using same type for Uint256 and Uint160, so use the original for now

--- a/utils/most_significant_bit.go
+++ b/utils/most_significant_bit.go
@@ -25,7 +25,7 @@ var powersOf2 = []powerOf2{
 }
 
 func MostSignificantBit(x *uint256.Int) (uint, error) {
-	if x.Sign() == 0 {
+	if x.IsZero() {
 		return 0, ErrInvalidInput
 	}
 

--- a/utils/sqrtprice_math.go
+++ b/utils/sqrtprice_math.go
@@ -29,11 +29,13 @@ func addIn256(x, y, sum *uint256.Int) *uint256.Int {
 
 // deprecated
 func GetAmount0Delta(sqrtRatioAX96, sqrtRatioBX96, liquidity *big.Int, roundUp bool) *big.Int {
-	res, err := GetAmount0DeltaV2(
+	var res uint256.Int
+	err := GetAmount0DeltaV2(
 		uint256.MustFromBig(sqrtRatioAX96),
 		uint256.MustFromBig(sqrtRatioBX96),
 		uint256.MustFromBig(liquidity),
 		roundUp,
+		&res,
 	)
 	if err != nil {
 		panic(err)
@@ -41,7 +43,7 @@ func GetAmount0Delta(sqrtRatioAX96, sqrtRatioBX96, liquidity *big.Int, roundUp b
 	return res.ToBig()
 }
 
-func GetAmount0DeltaV2(sqrtRatioAX96, sqrtRatioBX96 *Uint160, liquidity *Uint128, roundUp bool) (*uint256.Int, error) {
+func GetAmount0DeltaV2(sqrtRatioAX96, sqrtRatioBX96 *Uint160, liquidity *Uint128, roundUp bool, result *Uint256) error {
 	// https://github.com/Uniswap/v3-core/blob/d8b1c635c275d2a9450bd6a78f3fa2484fef73eb/contracts/libraries/SqrtPriceMath.sol#L159
 	if sqrtRatioAX96.Cmp(sqrtRatioBX96) > 0 {
 		sqrtRatioAX96, sqrtRatioBX96 = sqrtRatioBX96, sqrtRatioAX96
@@ -55,27 +57,30 @@ func GetAmount0DeltaV2(sqrtRatioAX96, sqrtRatioBX96 *Uint160, liquidity *Uint128
 		var deno Uint256
 		err := MulDivRoundingUpV2(&numerator1, &numerator2, sqrtRatioBX96, &deno)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		return DivRoundingUp(&deno, sqrtRatioAX96), nil
+		DivRoundingUp(&deno, sqrtRatioAX96, result)
+		return nil
 	}
 	// : FullMath.mulDiv(numerator1, numerator2, sqrtRatioBX96) / sqrtRatioAX96;
 	var tmp Uint256
 	err := MulDivV2(&numerator1, &numerator2, sqrtRatioBX96, &tmp, nil)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	result := new(uint256.Int).Div(&tmp, sqrtRatioAX96)
-	return result, nil
+	result.Div(&tmp, sqrtRatioAX96)
+	return nil
 }
 
 // deprecated
 func GetAmount1Delta(sqrtRatioAX96, sqrtRatioBX96, liquidity *big.Int, roundUp bool) *big.Int {
-	res, err := GetAmount1DeltaV2(
+	var res Uint256
+	err := GetAmount1DeltaV2(
 		uint256.MustFromBig(sqrtRatioAX96),
 		uint256.MustFromBig(sqrtRatioBX96),
 		uint256.MustFromBig(liquidity),
 		roundUp,
+		&res,
 	)
 	if err != nil {
 		panic(err)
@@ -83,88 +88,90 @@ func GetAmount1Delta(sqrtRatioAX96, sqrtRatioBX96, liquidity *big.Int, roundUp b
 	return res.ToBig()
 }
 
-func GetAmount1DeltaV2(sqrtRatioAX96, sqrtRatioBX96 *Uint160, liquidity *Uint128, roundUp bool) (*uint256.Int, error) {
+func GetAmount1DeltaV2(sqrtRatioAX96, sqrtRatioBX96 *Uint160, liquidity *Uint128, roundUp bool, result *Uint256) error {
 	// https://github.com/Uniswap/v3-core/blob/d8b1c635c275d2a9450bd6a78f3fa2484fef73eb/contracts/libraries/SqrtPriceMath.sol#L188
 	if sqrtRatioAX96.Cmp(sqrtRatioBX96) > 0 {
 		sqrtRatioAX96, sqrtRatioBX96 = sqrtRatioBX96, sqrtRatioAX96
 	}
 
-	var diff, result uint256.Int
+	var diff uint256.Int
 	diff.Sub(sqrtRatioBX96, sqrtRatioAX96)
 	if roundUp {
-		err := MulDivRoundingUpV2(liquidity, &diff, constants.Q96U256, &result)
+		err := MulDivRoundingUpV2(liquidity, &diff, constants.Q96U256, result)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		return &result, nil
+		return nil
 	}
 	// : FullMath.mulDiv(liquidity, sqrtRatioBX96 - sqrtRatioAX96, FixedPoint96.Q96);
-	err := MulDivV2(liquidity, &diff, constants.Q96U256, &result, nil)
+	err := MulDivV2(liquidity, &diff, constants.Q96U256, result, nil)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return &result, nil
+	return nil
 }
 
-func GetNextSqrtPriceFromInput(sqrtPX96 *Uint160, liquidity *Uint128, amountIn *uint256.Int, zeroForOne bool) (*Uint160, error) {
+func GetNextSqrtPriceFromInput(sqrtPX96 *Uint160, liquidity *Uint128, amountIn *uint256.Int, zeroForOne bool, result *Uint160) error {
 	if sqrtPX96.Sign() <= 0 {
-		return nil, ErrSqrtPriceLessThanZero
+		return ErrSqrtPriceLessThanZero
 	}
 	if liquidity.Sign() <= 0 {
-		return nil, ErrLiquidityLessThanZero
+		return ErrLiquidityLessThanZero
 	}
 	if zeroForOne {
-		return getNextSqrtPriceFromAmount0RoundingUp(sqrtPX96, liquidity, amountIn, true)
+		return getNextSqrtPriceFromAmount0RoundingUp(sqrtPX96, liquidity, amountIn, true, result)
 	}
-	return getNextSqrtPriceFromAmount1RoundingDown(sqrtPX96, liquidity, amountIn, true)
+	return getNextSqrtPriceFromAmount1RoundingDown(sqrtPX96, liquidity, amountIn, true, result)
 }
 
-func GetNextSqrtPriceFromOutput(sqrtPX96 *Uint160, liquidity *Uint128, amountOut *uint256.Int, zeroForOne bool) (*Uint160, error) {
+func GetNextSqrtPriceFromOutput(sqrtPX96 *Uint160, liquidity *Uint128, amountOut *uint256.Int, zeroForOne bool, result *Uint160) error {
 	if sqrtPX96.Sign() <= 0 {
-		return nil, ErrSqrtPriceLessThanZero
+		return ErrSqrtPriceLessThanZero
 	}
 	if liquidity.Sign() <= 0 {
-		return nil, ErrLiquidityLessThanZero
+		return ErrLiquidityLessThanZero
 	}
 	if zeroForOne {
-		return getNextSqrtPriceFromAmount1RoundingDown(sqrtPX96, liquidity, amountOut, false)
+		return getNextSqrtPriceFromAmount1RoundingDown(sqrtPX96, liquidity, amountOut, false, result)
 	}
-	return getNextSqrtPriceFromAmount0RoundingUp(sqrtPX96, liquidity, amountOut, false)
+	return getNextSqrtPriceFromAmount0RoundingUp(sqrtPX96, liquidity, amountOut, false, result)
 }
 
-func getNextSqrtPriceFromAmount0RoundingUp(sqrtPX96 *Uint160, liquidity *Uint128, amount *uint256.Int, add bool) (*Uint160, error) {
+func getNextSqrtPriceFromAmount0RoundingUp(sqrtPX96 *Uint160, liquidity *Uint128, amount *uint256.Int, add bool, result *Uint160) error {
 	if amount.IsZero() {
-		return sqrtPX96, nil
+		result.Set(sqrtPX96)
+		return nil
 	}
 
-	var numerator1, denominator, product, tmp, result uint256.Int
+	var numerator1, denominator, product, tmp uint256.Int
 	numerator1.Lsh(liquidity, 96)
 	multiplyIn256(amount, sqrtPX96, &product)
 	if add {
 		if tmp.Div(&product, amount).Cmp(sqrtPX96) == 0 {
 			addIn256(&numerator1, &product, &denominator)
 			if denominator.Cmp(&numerator1) >= 0 {
-				err := MulDivRoundingUpV2(&numerator1, sqrtPX96, &denominator, &result)
-				return &result, err
+				err := MulDivRoundingUpV2(&numerator1, sqrtPX96, &denominator, result)
+				return err
 			}
 		}
 		tmp.Div(&numerator1, sqrtPX96)
 		tmp.Add(&tmp, amount)
-		return DivRoundingUp(&numerator1, &tmp), nil
+		DivRoundingUp(&numerator1, &tmp, result)
+		return nil
 	} else {
 		if tmp.Div(&product, amount).Cmp(sqrtPX96) != 0 {
-			return nil, ErrInvariant
+			return ErrInvariant
 		}
 		if numerator1.Cmp(&product) <= 0 {
-			return nil, ErrInvariant
+			return ErrInvariant
 		}
 		denominator.Sub(&numerator1, &product)
-		err := MulDivRoundingUpV2(&numerator1, sqrtPX96, &denominator, &result)
-		return &result, err
+		err := MulDivRoundingUpV2(&numerator1, sqrtPX96, &denominator, result)
+		return err
 	}
 }
 
-func getNextSqrtPriceFromAmount1RoundingDown(sqrtPX96 *Uint160, liquidity *Uint128, amount *uint256.Int, add bool) (*Uint160, error) {
+func getNextSqrtPriceFromAmount1RoundingDown(sqrtPX96 *Uint160, liquidity *Uint128, amount *uint256.Int, add bool, result *Uint160) error {
 	if add {
 		var quotient, tmp uint256.Int
 		if amount.Cmp(MaxUint160) <= 0 {
@@ -176,24 +183,26 @@ func getNextSqrtPriceFromAmount1RoundingDown(sqrtPX96 *Uint160, liquidity *Uint1
 		}
 		_, overflow := quotient.AddOverflow(&quotient, sqrtPX96)
 		if overflow {
-			return nil, ErrAddOverflow
+			return ErrAddOverflow
 		}
 		err := CheckToUint160(&quotient)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		return &quotient, nil
+		result.Set(&quotient)
+		return nil
 	}
 
 	var quotient Uint256
 	err := MulDivRoundingUpV2(amount, constants.Q96U256, liquidity, &quotient)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if sqrtPX96.Cmp(&quotient) <= 0 {
-		return nil, ErrInvariant
+		return ErrInvariant
 	}
 	quotient.Sub(sqrtPX96, &quotient)
 	// always fits 160 bits
-	return &quotient, nil
+	result.Set(&quotient)
+	return nil
 }

--- a/utils/swap_math.go
+++ b/utils/swap_math.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"github.com/KyberNetwork/int256"
 	"github.com/KyberNetwork/uniswapv3-sdk-uint256/constants"
 	"github.com/holiman/uint256"
 )
@@ -14,9 +13,11 @@ func ComputeSwapStep(
 	sqrtRatioCurrentX96,
 	sqrtRatioTargetX96 *Uint160,
 	liquidity *Uint128,
-	amountRemaining *int256.Int,
+	amountRemaining *Int256,
 	feePips constants.FeeAmount,
-) (sqrtRatioNextX96 *Uint160, amountIn, amountOut, feeAmount *uint256.Int, err error) {
+
+	sqrtRatioNextX96 *Uint160, amountIn, amountOut, feeAmount *Uint256,
+) error {
 	zeroForOne := sqrtRatioCurrentX96.Cmp(sqrtRatioTargetX96) >= 0
 	exactIn := amountRemaining.Sign() >= 0
 
@@ -35,42 +36,42 @@ func ComputeSwapStep(
 		tmp.Mul(&amountRemainingU, &maxFeeMinusFeePips)
 		amountRemainingLessFee.Div(&tmp, MaxFeeUint256)
 		if zeroForOne {
-			amountIn, err = GetAmount0DeltaV2(sqrtRatioTargetX96, sqrtRatioCurrentX96, liquidity, true)
+			err := GetAmount0DeltaV2(sqrtRatioTargetX96, sqrtRatioCurrentX96, liquidity, true, amountIn)
 			if err != nil {
-				return
+				return err
 			}
 		} else {
-			amountIn, err = GetAmount1DeltaV2(sqrtRatioCurrentX96, sqrtRatioTargetX96, liquidity, true)
+			err := GetAmount1DeltaV2(sqrtRatioCurrentX96, sqrtRatioTargetX96, liquidity, true, amountIn)
 			if err != nil {
-				return
+				return err
 			}
 		}
 		if amountRemainingLessFee.Cmp(amountIn) >= 0 {
-			sqrtRatioNextX96 = sqrtRatioTargetX96
+			sqrtRatioNextX96.Set(sqrtRatioTargetX96)
 		} else {
-			sqrtRatioNextX96, err = GetNextSqrtPriceFromInput(sqrtRatioCurrentX96, liquidity, &amountRemainingLessFee, zeroForOne)
+			err := GetNextSqrtPriceFromInput(sqrtRatioCurrentX96, liquidity, &amountRemainingLessFee, zeroForOne, sqrtRatioNextX96)
 			if err != nil {
-				return
+				return err
 			}
 		}
 	} else {
 		if zeroForOne {
-			amountOut, err = GetAmount1DeltaV2(sqrtRatioTargetX96, sqrtRatioCurrentX96, liquidity, false)
+			err := GetAmount1DeltaV2(sqrtRatioTargetX96, sqrtRatioCurrentX96, liquidity, false, amountOut)
 			if err != nil {
-				return
+				return err
 			}
 		} else {
-			amountOut, err = GetAmount0DeltaV2(sqrtRatioCurrentX96, sqrtRatioTargetX96, liquidity, false)
+			err := GetAmount0DeltaV2(sqrtRatioCurrentX96, sqrtRatioTargetX96, liquidity, false, amountOut)
 			if err != nil {
-				return
+				return err
 			}
 		}
 		if amountRemainingU.Cmp(amountOut) >= 0 {
-			sqrtRatioNextX96 = sqrtRatioTargetX96
+			sqrtRatioNextX96.Set(sqrtRatioTargetX96)
 		} else {
-			sqrtRatioNextX96, err = GetNextSqrtPriceFromOutput(sqrtRatioCurrentX96, liquidity, &amountRemainingU, zeroForOne)
+			err := GetNextSqrtPriceFromOutput(sqrtRatioCurrentX96, liquidity, &amountRemainingU, zeroForOne, sqrtRatioNextX96)
 			if err != nil {
-				return
+				return err
 			}
 		}
 	}
@@ -79,48 +80,45 @@ func ComputeSwapStep(
 
 	if zeroForOne {
 		if !(max && exactIn) {
-			amountIn, err = GetAmount0DeltaV2(sqrtRatioNextX96, sqrtRatioCurrentX96, liquidity, true)
+			err := GetAmount0DeltaV2(sqrtRatioNextX96, sqrtRatioCurrentX96, liquidity, true, amountIn)
 			if err != nil {
-				return
+				return err
 			}
 		}
 		if !(max && !exactIn) {
-			amountOut, err = GetAmount1DeltaV2(sqrtRatioNextX96, sqrtRatioCurrentX96, liquidity, false)
+			err := GetAmount1DeltaV2(sqrtRatioNextX96, sqrtRatioCurrentX96, liquidity, false, amountOut)
 			if err != nil {
-				return
+				return err
 			}
 		}
 	} else {
 		if !(max && exactIn) {
-			amountIn, err = GetAmount1DeltaV2(sqrtRatioCurrentX96, sqrtRatioNextX96, liquidity, true)
+			err := GetAmount1DeltaV2(sqrtRatioCurrentX96, sqrtRatioNextX96, liquidity, true, amountIn)
 			if err != nil {
-				return
+				return err
 			}
 		}
 		if !(max && !exactIn) {
-			amountOut, err = GetAmount0DeltaV2(sqrtRatioCurrentX96, sqrtRatioNextX96, liquidity, false)
+			err := GetAmount0DeltaV2(sqrtRatioCurrentX96, sqrtRatioNextX96, liquidity, false, amountOut)
 			if err != nil {
-				return
+				return err
 			}
 		}
 	}
 
 	if !exactIn && amountOut.Cmp(&amountRemainingU) > 0 {
-		amountOut = &amountRemainingU
+		amountOut.Set(&amountRemainingU)
 	}
 
 	if exactIn && sqrtRatioNextX96.Cmp(sqrtRatioTargetX96) != 0 {
 		// we didn't reach the target, so take the remainder of the maximum input as fee
-		feeAmount = new(uint256.Int).Sub(&amountRemainingU, amountIn)
+		feeAmount.Sub(&amountRemainingU, amountIn)
 	} else {
-		if feeAmount == nil {
-			feeAmount = new(Uint256)
-		}
-		err = MulDivRoundingUpV2(amountIn, uint256.NewInt(uint64(feePips)), &maxFeeMinusFeePips, feeAmount)
+		err := MulDivRoundingUpV2(amountIn, uint256.NewInt(uint64(feePips)), &maxFeeMinusFeePips, feeAmount)
 		if err != nil {
-			return
+			return err
 		}
 	}
 
-	return
+	return nil
 }

--- a/utils/swap_math.go
+++ b/utils/swap_math.go
@@ -1,14 +1,10 @@
 package utils
 
 import (
-	"math/big"
-
 	"github.com/KyberNetwork/int256"
 	"github.com/KyberNetwork/uniswapv3-sdk-uint256/constants"
 	"github.com/holiman/uint256"
 )
-
-var MaxFee = new(big.Int).Exp(big.NewInt(10), big.NewInt(6), nil)
 
 const MaxFeeInt = 1000000
 
@@ -26,12 +22,9 @@ func ComputeSwapStep(
 
 	var amountRemainingU uint256.Int
 	if exactIn {
-		amountRemainingBI := amountRemaining.ToBig()
-		amountRemainingU.SetFromBig(amountRemainingBI) // TODO: optimize this
+		ToUInt256(amountRemaining, &amountRemainingU)
 	} else {
-		amountRemaining1 := new(int256.Int).Set(amountRemaining)
-		amountRemainingBI := amountRemaining1.ToBig()
-		amountRemainingU.SetFromBig(amountRemainingBI) // TODO: optimize this
+		ToUInt256(amountRemaining, &amountRemainingU)
 		amountRemainingU.Neg(&amountRemainingU)
 	}
 
@@ -120,7 +113,10 @@ func ComputeSwapStep(
 		// we didn't reach the target, so take the remainder of the maximum input as fee
 		feeAmount = new(uint256.Int).Sub(&amountRemainingU, amountIn)
 	} else {
-		feeAmount, err = MulDivRoundingUp(amountIn, uint256.NewInt(uint64(feePips)), &maxFeeMinusFeePips)
+		if feeAmount == nil {
+			feeAmount = new(Uint256)
+		}
+		err = MulDivRoundingUpV2(amountIn, uint256.NewInt(uint64(feePips)), &maxFeeMinusFeePips, feeAmount)
 		if err != nil {
 			return
 		}

--- a/utils/swap_math_test.go
+++ b/utils/swap_math_test.go
@@ -57,14 +57,17 @@ func TestComputeSwapStep(t *testing.T) {
 		{"20282409603651670423947251286016", "18254168643286503381552526157414", "1024", "-263000", 3000,
 			"1", "26214", "1", "="},
 	}
+	var sqrtRatioNextX96 Uint160
+	var amountIn, amountOut, feeAmount Uint256
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("test %d", i), func(t *testing.T) {
-			sqrtRatioNextX96, amountIn, amountOut, feeAmount, err := ComputeSwapStep(
+			err := ComputeSwapStep(
 				uint256.MustFromDecimal(tt.price),
 				uint256.MustFromDecimal(tt.priceTarget),
 				uint256.MustFromDecimal(tt.liquidity),
 				int256.MustFromDec(tt.amount),
 				tt.fee,
+				&sqrtRatioNextX96, &amountIn, &amountOut, &feeAmount,
 			)
 			require.Nil(t, err)
 			if tt.expNextPrice == "=" {

--- a/utils/tick_math_test.go
+++ b/utils/tick_math_test.go
@@ -19,8 +19,9 @@ func TestGetSqrtRatioAtTick(t *testing.T) {
 	rmax, _ := GetSqrtRatioAtTick(MinTick)
 	assert.Equal(t, rmax, MinSqrtRatio, "returns the correct value for min tick")
 
-	r, _ := GetSqrtRatioAtTickV2(MinTick + 1)
-	assert.Equal(t, uint256.NewInt(4295343490), r, "returns the correct value for min tick + 1")
+	var r Uint160
+	_ = GetSqrtRatioAtTickV2(MinTick+1, &r)
+	assert.Equal(t, uint256.NewInt(4295343490), &r, "returns the correct value for min tick + 1")
 
 	r0, _ := GetSqrtRatioAtTick(0)
 	assert.Equal(t, r0, new(big.Int).Lsh(constants.One, 96), "returns the correct value for tick 0")
@@ -28,11 +29,11 @@ func TestGetSqrtRatioAtTick(t *testing.T) {
 	rmin, _ := GetSqrtRatioAtTick(MaxTick)
 	assert.Equal(t, rmin, MaxSqrtRatio, "returns the correct value for max tick")
 
-	r, _ = GetSqrtRatioAtTickV2(MaxTick - 1)
-	assert.Equal(t, uint256.MustFromDecimal("1461373636630004318706518188784493106690254656249"), r, "returns the correct value for max tick - 1")
+	_ = GetSqrtRatioAtTickV2(MaxTick-1, &r)
+	assert.Equal(t, uint256.MustFromDecimal("1461373636630004318706518188784493106690254656249"), &r, "returns the correct value for max tick - 1")
 
-	r, _ = GetSqrtRatioAtTickV2(MaxTick)
-	assert.Equal(t, uint256.MustFromDecimal("1461446703485210103287273052203988822378723970342"), r, "returns the correct value for max tick")
+	_ = GetSqrtRatioAtTickV2(MaxTick, &r)
+	assert.Equal(t, uint256.MustFromDecimal("1461446703485210103287273052203988822378723970342"), &r, "returns the correct value for max tick")
 }
 
 func TestGetTickAtSqrtRatio(t *testing.T) {


### PR DESCRIPTION
- caller will pass pointer to the callee so it can write the result there, instead of callee allocating and returning new value
- add `GetOutputAmountV2` to return only necessary data (without calling NewPool again)
- optimize MulDiv following univ3-core code (avoiding bigInt)